### PR TITLE
perf: move archive exclusions to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Exclude files and directories from Git archives (including Packagist)
+.github/ export-ignore
+docs/ export-ignore
+examples/ export-ignore
+tests/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+.releaserc.json export-ignore
+codecov.yml export-ignore
+commitlint.config.mjs export-ignore
+grumphp.yml.dist export-ignore
+phpunit*.xml* export-ignore
+phpstan.neon.dist export-ignore
+psalm.xml.dist export-ignore
+rector.php export-ignore

--- a/composer.json
+++ b/composer.json
@@ -77,23 +77,5 @@
         "security": "@check --tasks=securitychecker_roave",
         "test": "@check --tasks=phpunit",
         "test:coverage": "vendor/bin/phpunit --coverage-clover=coverage.xml"
-    },
-    "archive": {
-        "exclude": [
-            ".github/*",
-            "docs/*",
-            "examples/*",
-            "tests/*",
-            ".gitignore",
-            ".php-cs-fixer.dist.php",
-            ".releaserc.json",
-            "codecov.yml",
-            "commitlint.config.mjs",
-            "grumphp.yml.dist",
-            "phpunit*.xml*",
-            "phpstan.neon.dist",
-            "psalm.xml.dist",
-            "rector.php"
-        ]
     }
 }


### PR DESCRIPTION
# Quick Fix

## Description
move archive exclusions to .gitattributes

## Type
- [ ] Bug fix
- [ ] New feature  
- [ ] Documentation
- [x] Code quality/refactor